### PR TITLE
Fix(?) accents for italics

### DIFF
--- a/bin/generate-fonts.py
+++ b/bin/generate-fonts.py
@@ -223,11 +223,11 @@ def referenceTransform(ref, glyph, deg):
     ri = psMat.inverse(r)
 
     result = psMat.identity()
-    result = psMat.compose(result, italicShiftRight(deg))
+    # result = psMat.compose(result, italicShiftRight(deg))
     result = psMat.compose(result, italicUnskew(deg))
     result = psMat.compose(result, r)
     result = psMat.compose(result, italicSkew(deg))
-    result = psMat.compose(result, italicShiftLeft(deg))
+    # result = psMat.compose(result, italicShiftLeft(deg))
 
     return (ref[0], result)
 


### PR DESCRIPTION
This change seems to put accents in a more sane place, at least for Swedish (and other Germanic languages) and French.

I had to upgrade the generate-fonts.py script to Python3 to get it to run with a modern version of FontForge, I got a ton of "internal errors" when running it, and now the lowercase 'e' has its upper floor flooded, so maybe it breaks something else — I know nothing about FontForge... Proceed with caution. :)

(Issue #1)